### PR TITLE
Change StarTrack-js URL to fit the new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Go 学习之路将会不断更新维护，如果有推荐的博客、微信公�
 
 [![Stargazers over time](https://starcharts.herokuapp.com/developer-learning/learning-golang.svg)](https://starcharts.herokuapp.com/developer-learning/learning-golang)
 
-[learning-golang Star History and Stats](https://seladb.github.io/StarTrack-js/?u=developer-learning&r=learning-golang)
+[learning-golang Star History and Stats](https://seladb.github.io/StarTrack-js/#/preload?r=developer-learning,learning-golang)
 
 ----
 


### PR DESCRIPTION
The current URL doesn't work with the new StarTrack-js version (2.x) so I've change it to fit the new version